### PR TITLE
adding a QC filter to UFO

### DIFF
--- a/src/ufo/filters/CMakeLists.txt
+++ b/src/ufo/filters/CMakeLists.txt
@@ -4,6 +4,8 @@
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 
 set ( filters_files
+      PracticalBoundsCheck.cc
+      PracticalBoundsCheck.h
       TrackCheckUtils.cc
       TrackCheckUtils.h
       TrackCheckUtilsParameters.h

--- a/src/ufo/instantiateObsFilterFactory.h
+++ b/src/ufo/instantiateObsFilterFactory.h
@@ -8,6 +8,7 @@
 #ifndef UFO_INSTANTIATEOBSFILTERFACTORY_H_
 #define UFO_INSTANTIATEOBSFILTERFACTORY_H_
 
+#include "ufo/filters/PracticalBoundsCheck.h"
 #include "oops/base/instantiateObsFilterFactory.h"
 #include "oops/interface/ObsFilter.h"
 #include "ufo/filters/BackgroundCheck.h"
@@ -83,6 +84,9 @@ template<typename MODEL> void instantiateObsFilterFactory() {
            legacyGaussianThinningMaker("Gaussian_Thinning");
   static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::TemporalThinning> >
            legacyTemporalThinningMaker("TemporalThinning");
+
+  static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::PracticalBoundsCheck> >
+     practicalBoundsCheckMaker("Practical Bounds Check");
 }
 
 }  // namespace ufo

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -139,6 +139,7 @@ list( APPEND ufo_test_input
   testinput/qc_trackcheckship_mainloop_unittests.yaml
   testinput/qc_backgroundcheck.yaml
   testinput/qc_boundscheck.yaml
+  testinput/qc_practical_boundscheck.yaml
   testinput/qc_velocitycheck.yaml
   testinput/qc_defer_to_post.yaml
   testinput/qc_derivative_dpdt.yaml
@@ -1095,6 +1096,12 @@ ecbuild_add_test( TARGET  test_ufo_opr_radarradialvelocity
                   TEST_DEPENDS ufo_get_ioda_test_data ufo_get_ufo_test_data )
 
 # Test UFO ObsFilters (generic)
+ecbuild_add_test( TARGET  test_ufo_qc_gen_practical_boundscheck
+                  COMMAND ${CMAKE_BINARY_DIR}/bin/test_ObsFilters.x
+                  ARGS    "testinput/qc_practical_boundscheck.yaml"
+                  ENVIRONMENT OOPS_TRAPFPE=1
+                  DEPENDS test_ObsFilters.x
+                  TEST_DEPENDS ufo_get_ufo_test_data )
 
 ecbuild_add_test( TARGET  test_ufo_qc_gen_processwhere
                   SOURCES mains/TestProcessWhere.cc


### PR DESCRIPTION
## Description

The new filter will check the observations vs. max/min limits. This is a new feature.

## Definition of Done

This is a test filter and only check the limits for given observations as described in the relevant yaml file. It does not provide any specific capability beyond checking the limits.

### Issue(s) addressed

This did not address any specific issue !

## Dependencies

No dependencies.

## Impact

Requires changes in the following repositories:
- [ ] ufo


