### PR TITLE
Adding a practical bounds check for ObsFilter

### DIFF
--- a/src/ufo/filters/CMakeLists.txt
+++ b/src/ufo/filters/CMakeLists.txt
@@ -20,6 +20,8 @@ set ( filters_files
       BlackList.h
       DifferenceCheck.cc
       DifferenceCheck.h
+      PracticalBoundsCheck.cc
+      PracticalBoundsCheck.h
       FilterBase.cc
       FilterBase.h
       getScalarOrFilterData.cc

--- a/src/ufo/filters/PracticalBoundsCheck.cc
+++ b/src/ufo/filters/PracticalBoundsCheck.cc
@@ -1,0 +1,84 @@
+/*
+ * (C) Copyright 2017-2018 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include "ufo/filters/PracticalBoundsCheck.h"
+
+#include <cmath>
+#include <vector>
+
+#include "eckit/config/Configuration.h"
+
+#include "ioda/ObsDataVector.h"
+#include "ioda/ObsSpace.h"
+
+#include "oops/util/Logger.h"
+
+namespace ufo {
+
+// -----------------------------------------------------------------------------
+
+PracticalBoundsCheck::PracticalBoundsCheck(ioda::ObsSpace & obsdb, const eckit::Configuration & config,
+                                 std::shared_ptr<ioda::ObsDataVector<int> > flags,
+                                 std::shared_ptr<ioda::ObsDataVector<float> > obserr)
+  : FilterBase(obsdb, config, flags, obserr)
+{
+  oops::Log::trace() << "PracticalBoundsCheck contructor starting" << std::endl;
+}
+
+// -----------------------------------------------------------------------------
+
+PracticalBoundsCheck::~PracticalBoundsCheck() {
+  oops::Log::trace() << "PracticalBoundsCheck destructed" << std::endl;
+}
+
+// -----------------------------------------------------------------------------
+
+void PracticalBoundsCheck::applyFilter(const std::vector<bool> & apply,
+                                  const Variables & filtervars,
+                                  std::vector<std::vector<bool>> & flagged) const {
+  oops::Log::trace() << "PracticalBoundsCheck priorFilter" << std::endl;
+
+  const float missing = util::missingValue(missing);
+  ufo::Variables testvars;
+  testvars += ufo::Variables(filtervars, "ObsValue");
+
+// min/max value setup
+  const float vmin = config_.getFloat("minvalue", missing);
+  const float vmax = config_.getFloat("maxvalue", missing);
+
+// Sanity checks
+  if (filtervars.nvars() == 0) {
+    oops::Log::error() << "No variables will be filtered out in filter."
+	               << config_ << std::endl;
+    ABORT("No variables specified to be filtered out in filter.");
+  }
+
+// Loop over all variables to filter
+  for (size_t jv = 0; jv < testvars.nvars(); ++jv) {
+    // get test data for this variable
+    std::vector<float> testdata;
+    data_.get(testvars.variable(jv), testdata);
+    // apply the filter
+    for (size_t jobs = 0; jobs < obsdb_.nlocs(); ++jobs) {
+      if (apply[jobs]) {
+        ASSERT(testdata[jobs] != missing);
+	if (vmin != missing && testdata[jobs] < vmin) flagged[jv][jobs] = true;
+	if (vmax != missing && testdata[jobs] > vmax) flagged[jv][jobs] = true;
+      }
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+void PracticalBoundsCheck::print(std::ostream & os) const {
+  os << "PracticalBoundsCheck::print not yet implemented ";
+}
+
+// -----------------------------------------------------------------------------
+
+}  // namespace ufo

--- a/src/ufo/filters/PracticalBoundsCheck.h
+++ b/src/ufo/filters/PracticalBoundsCheck.h
@@ -1,0 +1,53 @@
+/*
+ * (C) Copyright 2019 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef UFO_FILTERS_PRACTICALBOUNDSCHECK_H_
+#define UFO_FILTERS_PRACTICALBOUNDSCHECK_H_
+
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "oops/util/ObjectCounter.h"
+#include "ufo/filters/FilterBase.h"
+#include "ufo/filters/QCflags.h"
+#include "ufo/filters/Variable.h"
+
+namespace eckit {
+  class Configuration;
+}
+
+namespace ioda {
+  template <typename DATATYPE> class ObsDataVector;
+  class ObsSpace;
+}
+
+namespace ufo {
+
+/// PracticalBoundsCheck filter
+
+class PracticalBoundsCheck : public FilterBase,
+                        private util::ObjectCounter<PracticalBoundsCheck> {
+ public:
+  static const std::string classname() {return "ufo::PracticalBoundsCheck";}
+
+  PracticalBoundsCheck(ioda::ObsSpace &, const eckit::Configuration &,
+                  std::shared_ptr<ioda::ObsDataVector<int> >,
+                  std::shared_ptr<ioda::ObsDataVector<float> >);
+  ~PracticalBoundsCheck();
+
+ private:
+  void print(std::ostream &) const override;
+  void applyFilter(const std::vector<bool> &, const Variables &,
+                   std::vector<std::vector<bool>> &) const override;
+  int qcFlag() const override {return QCflags::bounds;}
+};
+
+}  // namespace ufo
+
+#endif  // UFO_FILTERS_PRACTICALBOUNDSCHECK_H_

--- a/src/ufo/instantiateObsFilterFactory.h
+++ b/src/ufo/instantiateObsFilterFactory.h
@@ -13,6 +13,7 @@
 #include "ufo/filters/BackgroundCheck.h"
 #include "ufo/filters/BlackList.h"
 #include "ufo/filters/DifferenceCheck.h"
+#include "ufo/filters/PracticalBoundsCheck.h"
 #include "ufo/filters/Gaussian_Thinning.h"
 #include "ufo/filters/MetOfficeBuddyCheck.h"
 #include "ufo/filters/MWCLWCheck.h"
@@ -49,6 +50,8 @@ template<typename MODEL> void instantiateObsFilterFactory() {
            backgroundCheckMaker("Background Check");
   static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::DifferenceCheck> >
            differenceCheckMaker("Difference Check");
+  static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::PracticalBoundsCheck> >
+	   practicalBoundsCheckMaker("Practical Bounds Check");
   static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::ROobserror> >
            ROobserrorMaker("ROobserror");
   static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::Thinning> >

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -157,6 +157,7 @@ list( APPEND ufo_test_input
   testinput/qc_thinning.yaml
   testinput/qc_temporal_thinning.yaml
   testinput/qc_temporal_thinning_unittests.yaml
+  testinput/qc_practical_boundscheck.yaml
   testinput/radiosonde.yaml
   testinput/radialvelocity.yaml
   testinput/reflectivity.yaml
@@ -1194,6 +1195,13 @@ ecbuild_add_test( TARGET  test_ufo_qc_trackcheck
                   ENVIRONMENT OOPS_TRAPFPE=1
                   DEPENDS test_ObsFilters.x
                   TEST_DEPENDS ufo_get_ioda_test_data ufo_get_ufo_test_data )
+
+ecbuild_add_test( TARGET  test_ufo_qc_gen_practical_boundscheck
+                  COMMAND ${CMAKE_BINARY_DIR}/bin/test_ObsFilters.x
+                  ARGS    "testinput/qc_practical_boundscheck.yaml"
+                  ENVIRONMENT OOPS_TRAPFPE=1
+                  DEPENDS test_ObsFilters.x
+                  TEST_DEPENDS ufo_get_ufo_test_data )
 
 ecbuild_add_test( TARGET  test_ufo_profileconsistencychecks_monolithicfilter
                   COMMAND ${CMAKE_BINARY_DIR}/bin/test_ObsFilters.x

--- a/test/testinput/qc_practical_boundscheck.yaml
+++ b/test/testinput/qc_practical_boundscheck.yaml
@@ -1,0 +1,45 @@
+window begin: 2018-01-01T00:00:00Z
+window end: 2019-01-01T00:00:00Z
+
+observations:
+- obs space:
+    name: test data
+    obsdatain:
+      obsfile: Data/ufo/testinput_tier_1/filters_testdata.nc4
+    simulated variables: [variable1, variable2, variable3]
+  obs filters:
+  #  Filter names are listed in
+  #  ufo/src/ufo/instantiateObsFilterFactory.h
+  - filter: Bounds Check        # test min/max value with all variables
+    filter variables:
+    - name: variable1
+    - name: variable2
+    - name: variable3
+    minvalue: 14.0
+    maxvalue: 19.0
+#  Compare variables with minvalue/maxvalue
+#  variable1@ObsValue = 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+#  variable2@ObsValue = 10, 12, 14, 16, 18, 20, 22, 24, 26, 28
+#  variable3@ObsValue = 25, 24, 23, 22, 21, 20, 19, 18, 17, 16
+#  number of data points passing the filter
+  passedBenchmark: 13
+- obs space:
+    name: test data
+    obsdatain:
+      obsfile: Data/ufo/testinput_tier_1/filters_testdata.nc4
+    simulated variables: [variable2, variable3]
+  obs filters:
+  #  Filter names are listed in
+  #  ufo/src/ufo/instantiateObsFilterFactory.h
+  - filter: Bounds Check
+    filter variables:
+    - name: variable2
+    - name: variable3
+    minvalue: 15.0
+    maxvalue: 20.0
+#  Compare variables with minvalue/maxvalue
+#  variable1@ObsValue = 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+#  variable2@ObsValue = 10, 12, 14, 16, 18, 20, 22, 24, 26, 28
+#  variable3@ObsValue = 25, 24, 23, 22, 21, 20, 19, 18, 17, 16
+#  number of data points passing the filter
+  passedBenchmark: 8


### PR DESCRIPTION
## Description

The new code in PracticalBoundsCheck.cc and PracticalBoundsCheck.h adds a new simplified bounds check for observations.  It adds this new feature within UFO.

## Definition of Done

The practical bounds check code is finished and new Ctests were added.  The filter works as expected.

### Issue(s) addressed

## Dependencies

## Impact

