### PR TITLE
Practal_boundscheck test -- checking obs within bounds

### DIFF
--- a/src/ufo/filters/CMakeLists.txt
+++ b/src/ufo/filters/CMakeLists.txt
@@ -55,6 +55,8 @@ set ( filters_files
       QCflags.h
       QCmanager.cc
       QCmanager.h
+      PracticalBoundsCheck.cc
+      PracticalBoundsCheck.h
       ProfileConsistencyChecks.cc
       ProfileConsistencyChecks.h
       ProfileConsistencyCheckParameters.h

--- a/src/ufo/filters/PracticalBoundsCheck.cc
+++ b/src/ufo/filters/PracticalBoundsCheck.cc
@@ -1,0 +1,84 @@
+/*
+ * (C) Copyright 2017-2018 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include "ufo/filters/PracticalBoundsCheck.h"
+
+#include <cmath>
+#include <vector>
+
+#include "eckit/config/Configuration.h"
+
+#include "ioda/ObsDataVector.h"
+#include "ioda/ObsSpace.h"
+
+#include "oops/util/Logger.h"
+
+namespace ufo {
+
+// -----------------------------------------------------------------------------
+
+PracticalBoundsCheck::PracticalBoundsCheck(ioda::ObsSpace & obsdb,
+                                           const eckit::Configuration & config,
+                                 std::shared_ptr<ioda::ObsDataVector<int> > flags,
+                                 std::shared_ptr<ioda::ObsDataVector<float> > obserr)
+  : FilterBase(obsdb, config, flags, obserr)
+{
+  oops::Log::trace() << "PracticalBoundsCheck contructor starting" << std::endl;
+}
+
+// -----------------------------------------------------------------------------
+
+PracticalBoundsCheck::~PracticalBoundsCheck() {
+  oops::Log::trace() << "PracticalBoundsCheck destructed" << std::endl;
+}
+
+// -----------------------------------------------------------------------------
+
+void PracticalBoundsCheck::applyFilter(const std::vector<bool> & apply,
+                                  const Variables & filtervars,
+                                  std::vector<std::vector<bool>> & flagged) const {
+  oops::Log::trace() << "PracticalBoundsCheck priorFilter" << std::endl;
+
+  const float missing = util::missingValue(missing);
+  ufo::Variables testvars;
+  testvars += ufo::Variables(filtervars, "ObsValue");
+
+  const float vmin = config_.getFloat("minvalue", missing);
+  const float vmax = config_.getFloat("maxvalue", missing);
+
+// Sanity checks
+  if (filtervars.nvars() == 0) {
+    oops::Log::error() << "No variables will be filtered out in filter "
+                       << config_ << std::endl;
+    ABORT("No variables specified to be filtered out in filter");
+  }
+
+// Loop over all variables to filter
+    for (size_t jv = 0; jv < testvars.nvars(); ++jv) {
+      //  get test data for this variable
+      std::vector<float> testdata;
+      data_.get(testvars.variable(jv), testdata);
+      //  apply the filter
+      for (size_t jobs = 0; jobs < obsdb_.nlocs(); ++jobs) {
+        if (apply[jobs]) {
+          ASSERT(testdata[jobs] != missing);
+          if (vmin != missing && testdata[jobs] < vmin) flagged[jv][jobs] = true;
+          if (vmax != missing && testdata[jobs] > vmax) flagged[jv][jobs] = true;
+        }
+      }
+    }
+}
+
+// -----------------------------------------------------------------------------
+
+void PracticalBoundsCheck::print(std::ostream & os) const {
+  os << "PracticalBoundsCheck::print not yet implemented ";
+}
+
+// -----------------------------------------------------------------------------
+
+}  // namespace ufo

--- a/src/ufo/filters/PracticalBoundsCheck.h
+++ b/src/ufo/filters/PracticalBoundsCheck.h
@@ -1,0 +1,54 @@
+/*
+ * (C) Copyright 2019 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef UFO_FILTERS_PRACTICALBOUNDSCHECK_H_
+#define UFO_FILTERS_PRACTICALBOUNDSCHECK_H_
+
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "oops/util/ObjectCounter.h"
+#include "ufo/filters/FilterBase.h"
+#include "ufo/filters/QCflags.h"
+#include "ufo/filters/Variable.h"
+
+namespace eckit {
+  class Configuration;
+}
+
+namespace ioda {
+  template <typename DATATYPE> class ObsDataVector;
+  class ObsSpace;
+}
+
+namespace ufo {
+
+/// PracticalBoundsCheck filter
+
+class PracticalBoundsCheck : public FilterBase,
+                        private util::ObjectCounter<PracticalBoundsCheck> {
+ public:
+  static const std::string classname() {return "ufo::PracticalBoundsCheck";}
+
+  PracticalBoundsCheck(ioda::ObsSpace &, const eckit::Configuration &,
+                  std::shared_ptr<ioda::ObsDataVector<int> >,
+                  std::shared_ptr<ioda::ObsDataVector<float> >);
+  ~PracticalBoundsCheck();
+
+ private:
+  void print(std::ostream &) const override;
+  void applyFilter(const std::vector<bool> &, const Variables &,
+                   std::vector<std::vector<bool>> &) const override;
+  int qcFlag() const override {return QCflags::bounds;}
+};
+
+}  // namespace ufo
+
+#endif  // UFO_FILTERS_PRACTICALBOUNDSCHECK_H_
+

--- a/src/ufo/instantiateObsFilterFactory.h
+++ b/src/ufo/instantiateObsFilterFactory.h
@@ -91,4 +91,3 @@ template<typename MODEL> void instantiateObsFilterFactory() {
 }  // namespace ufo
 
 #endif  // UFO_INSTANTIATEOBSFILTERFACTORY_H_
-

--- a/src/ufo/instantiateObsFilterFactory.h
+++ b/src/ufo/instantiateObsFilterFactory.h
@@ -22,6 +22,7 @@
 #include "ufo/filters/ObsDomainCheck.h"
 #include "ufo/filters/ObsDomainErrCheck.h"
 #include "ufo/filters/PoissonDiskThinning.h"
+#include "ufo/filters/PracticalBoundsCheck.h"
 #include "ufo/filters/PreQC.h"
 #include "ufo/filters/ProfileConsistencyChecks.h"
 #include "ufo/filters/QCmanager.h"
@@ -67,6 +68,8 @@ template<typename MODEL> void instantiateObsFilterFactory() {
            temporalThinningMaker("Temporal Thinning");
   static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::PoissonDiskThinning> >
            poissonDiskThinningMaker("Poisson Disk Thinning");
+  static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::PracticalBoundsCheck> >
+           practicalBoundsCheckMaker("Practical Bounds Check");
   static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::ObsDiagnosticsWriter> >
            YDIAGsaverMaker("YDIAGsaver");
   static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ufo::TrackCheck> >
@@ -88,3 +91,4 @@ template<typename MODEL> void instantiateObsFilterFactory() {
 }  // namespace ufo
 
 #endif  // UFO_INSTANTIATEOBSFILTERFACTORY_H_
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1096,6 +1096,13 @@ ecbuild_add_test( TARGET  test_ufo_opr_radarradialvelocity
 
 # Test UFO ObsFilters (generic)
 
+ecbuild_add_test( TARGET  test_ufo_qc_gen_practical_boundscheck
+                  COMMAND ${CMAKE_BINARY_DIR}/bin/test_ObsFilters.x
+                  ARGS    "testinput/qc_practical_boundscheck.yaml"
+                  ENVIRONMENT OOPS_TRAPFPE=1
+                  DEPENDS test_ObsFilters.x
+                  TEST_DEPENDS ufo_get_ufo_test_data )
+
 ecbuild_add_test( TARGET  test_ufo_qc_gen_processwhere
                   SOURCES mains/TestProcessWhere.cc
                   ARGS    "testinput/processwhere.yaml"

--- a/test/testinput/qc_practical_boundstest.yaml
+++ b/test/testinput/qc_practical_boundstest.yaml
@@ -1,0 +1,46 @@
+window begin: 2018-01-01T00:00:00Z
+window end: 2019-01-01T00:00:00Z
+
+observations:
+- obs space:
+    name: test data
+    obsdatain:
+      obsfile: Data/ufo/testinput_tier_1/filters_testdata.nc4
+    simulated variables: [variable1, variable2, variable3]
+  obs filters:
+  #  Filter names are listed in
+  #  ufo/src/ufo/instantiateObsFilterFactory.h
+  - filter: Practical Bounds Check        # test min/max value with all variables
+    filter variables:
+    - name: variable1
+    - name: variable2
+    - name: variable3
+    minvalue: 14.0
+    maxvalue: 19.0
+#  Compare variables with minvalue/maxvalue
+#  variable1@ObsValue = 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+#  variable2@ObsValue = 10, 12, 14, 16, 18, 20, 22, 24, 26, 28
+#  variable3@ObsValue = 25, 24, 23, 22, 21, 20, 19, 18, 17, 16
+#  number of data points passing the filter
+  passedBenchmark: 13
+
+- obs space:
+    name: test data
+    obsdatain:
+      obsfile: Data/ufo/testinput_tier_1/filters_testdata.nc4
+    simulated variables: [variable2, variable3]
+  obs filters:
+  #  Filter names are listed in
+  #  ufo/src/ufo/instantiateObsFilterFactory.h
+  - filter: Practical Bounds Check        # test min/max value with all variables
+    filter variables:
+    - name: variable2
+    - name: variable3
+    minvalue: 15.0
+    maxvalue: 20.0
+#  Compare variables with minvalue/maxvalue
+#  variable2@ObsValue = 10, 12, 14, 16, 18, 20, 22, 24, 26, 28
+#  variable3@ObsValue = 25, 24, 23, 22, 21, 20, 19, 18, 17, 16
+#  number of data points passing the filter
+  passedBenchmark: 8
+  


### PR DESCRIPTION

## Description

The addition of the PracticalBoundsCheck subroutine (from the Jedi Academy).
This checks whether observations are within certain absolute bounds. The real purpose is to test the git pull and review process. This change includes an unneccesary whitespace change at the end of src/ufo/instantiateObsFilterFactory.h (which might make a good test of the git review process). We shall see whether the tests fail (in which case, further code changes may be required). 

## Definition of Done

The new code must implement the (unnecessary) bounds check, and must meet coding standards (such that a reviewer approves it), so that I can feel a sense of achievement, and I can go off and make a cup of tea!

## Estimate

E1
Very little effort estimated
**I couldn't work out how to put "E" in** (as requested on https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/pullrequest.html for pull requests without an issue number -- please show me how this should be done!)

Link the issues to be closed with this PR
- fixes <completion of Jedi Academy (no issue number)>

## Dependencies

No dependencies

## Impact

I can feel a sense of achievement
I can go off and make a cup of tea!

No impact on other repositories

No updates to test data

